### PR TITLE
Autoload the FileSecurity class

### DIFF
--- a/VendorHardeningPlugin.php
+++ b/VendorHardeningPlugin.php
@@ -244,7 +244,6 @@ class VendorHardeningPlugin implements PluginInterface, EventSubscriberInterface
     // Make sure that we can autoload FileSecurity class.
     $this->autoloadFileSecurity();
     if (!class_exists(FileSecurity::class)) {
-      $this->io->writeError('<warning>Could not harden vendor directory with .htaccess and web.config files; drupal/core not found.</warning>');
       return;
     }
 
@@ -267,13 +266,21 @@ class VendorHardeningPlugin implements PluginInterface, EventSubscriberInterface
     // Find drupal/core
     $drupalCorePackage = $this->composer->getRepositoryManager()->getLocalRepository()->findPackage('drupal/core', '*');
     if (!$drupalCorePackage) {
+      $this->io->writeError('<warning>Could not harden vendor directory with .htaccess and web.config files; drupal/core not found.</warning>');
       return;
     }
     $installationManager = $this->composer->getInstallationManager();
     $corePath = realpath($installationManager->getInstallPath($drupalCorePackage));
 
+    $fileSecurityPath = 'lib/Drupal/Component/FileSecurity';
+
+    if (!is_dir("$corePath/$fileSecurityPath")) {
+      $this->io->writeError('<warning>Could not harden vendor directory with .htaccess and web.config files; drupal/core does contain the File Security component at $fileSecurityPath.</warning>');
+      return;
+    }
+
     $classLoader = new ClassLoader();
-    $classLoader->addPsr4('Drupal\\Component\\FileSecurity\\', "$corePath/lib/Drupal/Component/FileSecurity");
+    $classLoader->addPsr4('Drupal\\Component\\FileSecurity\\', "$corePath/$fileSecurityPath");
     $classLoader->register();
   }
 }

--- a/VendorHardeningPlugin.php
+++ b/VendorHardeningPlugin.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Composer\Plugin\VendorHardening;
 
-use Composer\Autoload\ClassLoader;
 use Composer\Composer;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\Installer\PackageEvent;
@@ -272,15 +271,13 @@ class VendorHardeningPlugin implements PluginInterface, EventSubscriberInterface
     $installationManager = $this->composer->getInstallationManager();
     $corePath = realpath($installationManager->getInstallPath($drupalCorePackage));
 
-    $fileSecurityPath = 'lib/Drupal/Component/FileSecurity';
+    $fileSecurityPath = 'lib/Drupal/Component/FileSecurity/FileSecurity.php';
 
     if (!is_dir("$corePath/$fileSecurityPath")) {
-      $this->io->writeError('<warning>Could not harden vendor directory with .htaccess and web.config files; drupal/core does contain the File Security component at $fileSecurityPath.</warning>');
+      $this->io->writeError('<warning>Could not harden vendor directory with .htaccess and web.config files; drupal/core does not contain the file security component at $fileSecurityPath.</warning>');
       return;
     }
 
-    $classLoader = new ClassLoader();
-    $classLoader->addPsr4('Drupal\\Component\\FileSecurity\\', "$corePath/$fileSecurityPath");
-    $classLoader->register();
+    require_once "$corePath/$fileSecurityPath";
   }
 }

--- a/VendorHardeningPlugin.php
+++ b/VendorHardeningPlugin.php
@@ -244,7 +244,7 @@ class VendorHardeningPlugin implements PluginInterface, EventSubscriberInterface
     // Make sure that we can autoload FileSecurity class.
     $this->autoloadFileSecurity();
     if (!class_exists(FileSecurity::class)) {
-      $this->io->writeError('<warning>Hardening vendor directory with .htaccess and web.config files.</warning>');
+      $this->io->writeError('<warning>Could not harden vendor directory with .htaccess and web.config files; drupal/core not found.</warning>');
       return;
     }
 

--- a/VendorHardeningPlugin.php
+++ b/VendorHardeningPlugin.php
@@ -273,8 +273,8 @@ class VendorHardeningPlugin implements PluginInterface, EventSubscriberInterface
 
     $fileSecurityPath = 'lib/Drupal/Component/FileSecurity/FileSecurity.php';
 
-    if (!is_dir("$corePath/$fileSecurityPath")) {
-      $this->io->writeError('<warning>Could not harden vendor directory with .htaccess and web.config files; drupal/core does not contain the file security component at $fileSecurityPath.</warning>');
+    if (!is_file("$corePath/$fileSecurityPath")) {
+      $this->io->writeError("<warning>Could not harden vendor directory with .htaccess and web.config files; drupal/core does not contain the file security component at $fileSecurityPath.</warning>");
       return;
     }
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
   },
   "require": {
     "php": ">=7.0.8",
-    "composer-plugin-api": "^1.1",
-    "drupal/core-file-security": "8.8.x-dev"
+    "composer-plugin-api": "^1.1"
   }
 }


### PR DESCRIPTION
If the FileSecurity class is not available, but we can find drupal/core, then add a class loader for it.

This works, but Composer still emits warnings that it cannot find drupal/core within the Vendor Hardening plugin context. These warnings are innocuous, but they look alarming.

```
$ composer dumpautoload
Could not scan for classes inside "/Users/ganderson/Code/open-source/drupal/drupal-drupal-composer/vendor/drupal/core/lib/Drupal.php" which does not appear to be a file nor a folder
Could not scan for classes inside "/Users/ganderson/Code/open-source/drupal/drupal-drupal-composer/vendor/drupal/core/lib/Drupal/Component/Utility/Timer.php" which does not appear to be a file nor a folder
Could not scan for classes inside "/Users/ganderson/Code/open-source/drupal/drupal-drupal-composer/vendor/drupal/core/lib/Drupal/Component/Utility/Unicode.php" which does not appear to be a file nor a folder
Could not scan for classes inside "/Users/ganderson/Code/open-source/drupal/drupal-drupal-composer/vendor/drupal/core/lib/Drupal/Core/Database/Database.php" which does not appear to be a file nor a folder
Could not scan for classes inside "/Users/ganderson/Code/open-source/drupal/drupal-drupal-composer/vendor/drupal/core/lib/Drupal/Core/DrupalKernel.php" which does not appear to be a file nor a folder
Could not scan for classes inside "/Users/ganderson/Code/open-source/drupal/drupal-drupal-composer/vendor/drupal/core/lib/Drupal/Core/DrupalKernelInterface.php" which does not appear to be a file nor a folder
Could not scan for classes inside "/Users/ganderson/Code/open-source/drupal/drupal-drupal-composer/vendor/drupal/core/lib/Drupal/Core/Site/Settings.php" which does not appear to be a file nor a folder
Generating autoload files
Hardening vendor directory with .htaccess and web.config files.
Generated autoload files containing 556 classes              
```

Perhaps these warnings are sufficient reason to abandon this alternative.